### PR TITLE
Separated child and pty into tuple.

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,7 +5,7 @@ mod main {
     use std::io::{Read as _, Write as _};
     use std::os::unix::io::AsRawFd as _;
 
-    pub fn run(pty: &mut pty_process::StdPty) {
+    pub fn run(pty: &mut pty_process::std::Pty) {
         let _raw = super::raw_guard::RawGuard::new();
         let mut buf = [0_u8; 4096];
         let pty_fd = pty.as_raw_fd();

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -1,2 +1,0 @@
-pub type Child =
-    crate::Child<async_process::Child, crate::pty::async_io::Pty>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,18 @@ pub use pty::Pty;
 pub use pty::Size;
 
 #[cfg(feature = "backend-async-std")]
-pub use pty::async_io::Pty as AsyncPty;
+pub mod async_io {
+    pub use super::pty::async_io::Pty;
+}
 #[cfg(feature = "backend-smol")]
-pub use pty::smol::Pty as SmolPty;
+pub mod smol {
+    pub use super::pty::smol::Pty;
+}
 #[cfg(feature = "backend-std")]
-pub use pty::std::Pty as StdPty;
+pub mod std {
+    pub use super::pty::std::Pty;
+}
 #[cfg(feature = "backend-tokio")]
-pub use pty::tokio::Pty as TokioPty;
+pub mod tokio {
+    pub use super::pty::tokio::Pty;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,15 +21,15 @@
 //! provides additional methods for interacting with the pty:
 //!
 //! ```no_run
-//! # use pty_process::Command as _;
+//! # use pty_process::{Command as _, Pty};
 //! #
 //! # let mut cmd = std::process::Command::new("nethack");
-//! # let mut child = cmd
+//! # let (mut child, mut pty) = cmd
 //! #   .spawn_pty(Some(&pty_process::Size::new(24, 80))).unwrap();
 //! use std::io::Write as _;
 //!
-//! child.pty().write_all(b"foo\n").unwrap();
-//! child.resize_pty(&pty_process::Size::new(30, 100)).unwrap();
+//! pty.write_all(b"foo\n").unwrap();
+//! pty.resize(&pty_process::Size::new(30, 100)).unwrap();
 //! let status = child.wait().unwrap();
 //! ```
 //!
@@ -46,17 +46,18 @@
 //! Any number of backends may be enabled, depending on your needs.
 
 mod command;
-pub use command::{Child, Command};
+pub use command::Command;
 mod error;
 pub use error::{Error, Result};
 mod pty;
+pub use pty::Pty;
 pub use pty::Size;
 
 #[cfg(feature = "backend-async-std")]
-pub mod async_std;
+pub use pty::async_io::Pty as AsyncPty;
 #[cfg(feature = "backend-smol")]
-pub mod smol;
+pub use pty::smol::Pty as SmolPty;
 #[cfg(feature = "backend-std")]
-pub mod std;
+pub use pty::std::Pty as StdPty;
 #[cfg(feature = "backend-tokio")]
-pub mod tokio;
+pub use pty::tokio::Pty as TokioPty;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -9,7 +9,7 @@ pub mod std;
 #[cfg(feature = "backend-tokio")]
 pub mod tokio;
 
-pub trait Pty {
+pub trait Pty: ::std::ops::Deref + ::std::ops::DerefMut {
     type Pt;
 
     fn new() -> Result<Self>

--- a/src/pty/async_io.rs
+++ b/src/pty/async_io.rs
@@ -47,3 +47,17 @@ impl super::Pty for Pty {
             .map_err(Error::SetTermSize)
     }
 }
+
+impl ::std::ops::Deref for Pty {
+    type Target = async_io::Async<std::fs::File>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pt
+    }
+}
+
+impl ::std::ops::DerefMut for Pty {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.pt
+    }
+}

--- a/src/pty/std.rs
+++ b/src/pty/std.rs
@@ -45,3 +45,17 @@ impl super::Pty for Pty {
             .map_err(Error::SetTermSize)
     }
 }
+
+impl ::std::ops::Deref for Pty {
+    type Target = std::fs::File;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pt
+    }
+}
+
+impl ::std::ops::DerefMut for Pty {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.pt
+    }
+}

--- a/src/smol.rs
+++ b/src/smol.rs
@@ -1,2 +1,0 @@
-pub type Child =
-    crate::Child<async_process::Child, crate::pty::async_io::Pty>;

--- a/src/std.rs
+++ b/src/std.rs
@@ -1,1 +1,0 @@
-pub type Child = crate::Child<std::process::Child, crate::pty::std::Pty>;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,1 +1,0 @@
-pub type Child = crate::Child<tokio::process::Child, crate::pty::tokio::Pty>;

--- a/tests/winch.rs
+++ b/tests/winch.rs
@@ -1,10 +1,10 @@
-use pty_process::Command as _;
+use pty_process::{Command as _, Pty};
 use std::io::{Read as _, Write as _};
 
 #[cfg(feature = "backend-std")]
 #[test]
 fn test_winch() {
-    let mut child = std::process::Command::new("perl")
+    let (mut child, mut pty) = std::process::Command::new("perl")
         .args(&[
             "-E",
             "$|++; $SIG{WINCH} = sub { say 'WINCH' }; say 'started'; <>",
@@ -13,15 +13,15 @@ fn test_winch() {
         .unwrap();
 
     let mut buf = [0u8; 1024];
-    let bytes = child.pty().read(&mut buf).unwrap();
+    let bytes = pty.read(&mut buf).unwrap();
     assert_eq!(&buf[..bytes], b"started\r\n");
 
-    child.resize_pty(&pty_process::Size::new(25, 80)).unwrap();
+    pty.resize(&pty_process::Size::new(25, 80)).unwrap();
 
-    let bytes = child.pty().read(&mut buf).unwrap();
+    let bytes = pty.read(&mut buf).unwrap();
     assert_eq!(&buf[..bytes], b"WINCH\r\n");
 
-    child.pty().write_all(b"\n").unwrap();
+    pty.write_all(b"\n").unwrap();
     let status = child.wait().unwrap();
     assert_eq!(status.code().unwrap(), 0);
 }


### PR DESCRIPTION
I needed the pty and the child separate, specifically because I wanted to wait for the process to terminate while also recording its input in Tokio. The technique your example used isn't working in my use case.

Breaking changes were required, but I made them as easy to repair as I could.