### PR TITLE
Add shim for ptsname on MacOS.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ nix = "0.26.2"
 
 tokio = { version = "1.26.0", features = ["fs", "process", "net"], optional = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+nix-ptsname_r-shim = { version = "0.2", git = "https://github.com/tmpfs/nix-ptsname_r-shim", branch = "nix-update" }
+
 [dev-dependencies]
 futures = "0.3.26"
 regex = "1.7.1"

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -31,10 +31,16 @@ impl Pty {
     }
 
     pub fn pts(&self) -> crate::Result<Pts> {
+        #[cfg(target_os = "linux")]
+        let ptsname = nix::pty::ptsname_r(&self.0)?;
+
+        #[cfg(target_os = "macos")]
+        let ptsname = nix_ptsname_r_shim::ptsname_r(&self.0)?;
+
         Ok(Pts(std::fs::OpenOptions::new()
             .read(true)
             .write(true)
-            .open(nix::pty::ptsname_r(&self.0)?)?
+            .open(ptsname)?
             .into()))
     }
 


### PR DESCRIPTION
Trying to use this on MacOS for integration testing of a CLI tool but there is an issue with ptsname_r not being found so this PR adds a shim implementation of ptsname.

The version of `nix` used by the shim was old and conflicted with the version here so I am using a `git` dependency for now, if the shim merges this PR:

https://github.com/Mobivity/nix-ptsname_r-shim/pull/4

Then we can revert.

Note that the tests still don't pass on MacOS due to missing `pipe2` function.