### PR TITLE
Prevent `Pty::pts()` from attaching via `O_NOCTTY`

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,6 +1,6 @@
 use std::os::{
     fd::{AsRawFd as _, FromRawFd as _},
-    unix::prelude::OsStrExt as _,
+    unix::prelude::{OpenOptionsExt as _, OsStrExt as _},
 };
 
 #[derive(Debug)]
@@ -43,6 +43,7 @@ impl Pty {
         Ok(Pts(std::fs::OpenOptions::new()
             .read(true)
             .write(true)
+            .custom_flags(libc::O_NOCTTY)
             .open(std::ffi::OsStr::from_bytes(
                 rustix::pty::ptsname(&self.0, vec![])?.as_bytes(),
             ))?


### PR DESCRIPTION
If a process doesn't have a controlling terminal (for example if it is in a new session) then `open(ptsname())` will automatically make the slave the controlling terminal of the process.

Later on, `command.spawn(&pts)`s call to `ioctl_tiocsctty()` within `session_leader()` within `command.pre_exec()` will fail as with EPERM since the parent process (and session) is alread using it as its controlling terminal.

Use `O_NOCTTY` to prevent this.

Tested on macOS and Linux.