### PR TITLE
Implement AsRawFd for &Pty

### DIFF
--- a/src/blocking/pty.rs
+++ b/src/blocking/pty.rs
@@ -48,6 +48,12 @@ impl std::os::fd::AsRawFd for Pty {
     }
 }
 
+impl std::os::fd::AsRawFd for &Pty {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
 impl std::io::Read for Pty {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.0.read(buf)


### PR DESCRIPTION
Some APIs, like `nonblock::NonBlockingReader::from_fd` take a value that implements AsRawFd.

Pty implements AsRawFd, but if we pass it by value, it will get moved, as it doesn't implement Clone or Copy.

With this change, &Pty can now be passed without moving the Pty.